### PR TITLE
make landmask generation thread-safe and multi-process safe

### DIFF
--- a/opendrift_landmask_data/mask.py
+++ b/opendrift_landmask_data/mask.py
@@ -7,6 +7,8 @@ import rasterio
 import tempfile
 import os
 import os.path
+import logging
+import threading
 
 from .gshhs import get_gshhs_f
 
@@ -29,6 +31,12 @@ class Landmask:
   transform = None
   invtransform = None
 
+  tmpdir = os.path.join (tempfile.gettempdir(), 'landmask')
+  mmapf = os.path.join(tmpdir, 'mask.dat')
+  lockf = os.path.join(tmpdir, '.mask.dat.lock')
+
+  generation_lock = threading.Lock()
+
   @staticmethod
   def get_mask():
     from pkg_resources import resource_stream
@@ -44,7 +52,86 @@ class Landmask:
     resy = float(y[1] - y[0]) / Landmask.ny
     return Affine.translation(x[0] - resx/2, y[0]-resy/2) * Affine.scale(resx, resy)
 
-  def __init__(self, extent = None, skippoly = False):
+  def __32_bit__(self):
+    import sys
+    return sys.maxsize <= 2**32
+
+  def __mask_exists__(self):
+    return os.path.exists(self.mmapf)
+
+  def __generate_impl__(self):
+    if self.__32_bit__():
+      raise Exception("numpy memory mapped file cannot exceed 2GB on 32 bit system")
+
+    if not self.__mask_exists__():
+      logging.info("generating memmap landmask from tif to %s.." % self.mmapf)
+
+      with tempfile.NamedTemporaryFile(dir = self.tmpdir, delete = False) as fd:
+        try:
+          mask = np.memmap(fd, dtype = 'uint8', mode = 'w+', shape = (self.ny, self.nx))
+          with rasterio.open(self.get_mask(), 'r') as src:
+            src.read(1, out = mask)
+
+          mask.flush()
+          del mask
+
+          if self.__concurreny_delay__:
+            logging.warn("concurrency tesing, sleeping: %.2fs" % self.__concurreny_delay__)
+            import time
+            time.sleep(self.__concurreny_delay__)
+
+          os.rename(fd.name, self.mmapf)
+          logging.info("landmask generated")
+
+        except:
+          os.unlink(fd.name)
+          raise
+
+  def __generate__(self):
+    if not os.path.exists(self.tmpdir):
+      os.makedirs (self.tmpdir)
+
+    if self.generation_lock.acquire(blocking = False):
+      try:
+        import fcntl
+
+        with open(self.lockf, 'w') as fd:
+          # try to get non-blocking lock, if fail, another process is presumably generating the
+          # landmask. so we wait.
+          try:
+            logging.info("locking landmask for generation..")
+            fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            logging.info("got lock")
+
+            # we got the lock, now generate mask
+            self.__generate_impl__()
+
+          except OSError:
+            # file already locked
+            logging.warn("landmask is being generated in another process, waiting for it to complete..")
+
+            fcntl.lockf(fd, fcntl.LOCK_EX) # blocks
+
+            logging.info("landmask generation done in another process, attempting to load..")
+
+      except ImportError:
+        logging.error("fcntl not available on this platform, concurrent generations of landmask (different threads or processes) might cause failing landmask generation. Make sure only one instance of landmask is running on system the first time.")
+        self.__generate_impl__()
+
+      finally:
+        self.generation_lock.release()
+
+    else:
+      logging.info("landmask is being generated in another thread, waiting for it to complete..")
+      self.generation_lock.acquire(True)
+      self.generation_lock.release()
+      logging.info("landmask generation done in another thread, attempting to load..")
+
+
+  def __open_mask__(self):
+    self.mask = np.memmap (self.mmapf, dtype = 'uint8', mode = 'r', shape = (self.ny, self.nx))
+
+  def __init__(self, extent = None, skippoly = False, __concurreny_delay__ = 0):
     """
     Initialize landmask from generated GeoTIFF
 
@@ -52,26 +139,19 @@ class Landmask:
 
       extent (array): [xmin, ymin, xmax, ymax]
       skippoly (bool): do not load polygons
+
+      __concurreny_delay__: internally used for race condition testing, do not use.
     """
     self.extent = extent
     self.transform = self.get_transform()
     self.invtransform = self.transform.__invert__()
     self.skippoly = skippoly
+    self.__concurreny_delay__ = __concurreny_delay__
 
-    tmpdir = os.path.join (tempfile.gettempdir(), 'landmask')
-    if not os.path.exists(tmpdir): os.makedirs (tmpdir)
+    if not self.__mask_exists__():
+      self.__generate__()
 
-    mmapf = os.path.join(tmpdir, 'mask.dat')
-    if not os.path.exists (mmapf):
-      print ("generating memmap landmask from tif..")
-      self.mask  = np.memmap (mmapf, dtype = 'uint8', mode = 'w+', shape = (self.ny, self.nx))
-
-      with rasterio.open(self.get_mask(), 'r') as src:
-        src.read(1, out = self.mask)
-
-      del self.mask
-
-    self.mask  = np.memmap (mmapf, dtype = 'uint8', mode = 'r', shape = (self.ny, self.nx))
+    self.__open_mask__()
 
     if not skippoly:
       with get_gshhs_f() as fd:


### PR DESCRIPTION
also make generation more robust by renaming file after generation and
deleting failed attempts.